### PR TITLE
[RDM ONLY]: add support for kecleon boards

### DIFF
--- a/config_example/boards.json
+++ b/config_example/boards.json
@@ -8,6 +8,9 @@
     "quests": [
 
     ],
+    "kecleon": [
+
+    ],
     "eggs": [
         
     ],

--- a/config_example/config.ini
+++ b/config_example/config.ini
@@ -26,6 +26,7 @@ channels = [""]
 pokemon_aliases = ["mon", "mons", "poke", "p"]
 gyms_aliases = ["gym", "g"]
 quest_aliases = ["quests", "research", "q"]
+kecleon_aliases = ["kecleon", "k"]
 
 show_used_timespan_in_footer = False
 

--- a/data/dts/en.json
+++ b/data/dts/en.json
@@ -48,5 +48,6 @@
     "loading_quests": "Loading Quests",
     "no_quests_found": "❌ No Quests were found",
 	"average_iv": "📊 Average IV",
-	"average_iv_of_active_mons": "📊 Average IV of active Pokémon"
+	"average_iv_of_active_mons": "📊 Average IV of active Pokémon",
+    "unknown_stop_name": "Unknown stop name"
 }

--- a/default.ini
+++ b/default.ini
@@ -26,6 +26,7 @@ channels = [""]
 pokemon_aliases = ["mon", "mons", "poke", "p"]
 gyms_aliases = ["gym", "g"]
 quest_aliases = ["quests", "research", "q"]
+kecleon_aliases = ["kecleon", "k"]
 
 show_used_timespan_in_footer = False
 


### PR DESCRIPTION
Adds kecleon board:
![kecleon_board](https://user-images.githubusercontent.com/2726293/212986784-7b23cf4c-a435-4cab-922b-24d4a212546c.png)

Example boards.json:
```
    ...
    "kecleon": [
        {
            "channel_id": xxx,
            "message_id": xxx,
            "title": "Where is Kecleon?",
            "area": "area_name",
            "timezone": "-03:00",
        }
    ],
    ...
    ```
    
Still need to adjust the query for MAD